### PR TITLE
Refactor/node cache flow

### DIFF
--- a/.azure-pipelines/ci/branches.yml
+++ b/.azure-pipelines/ci/branches.yml
@@ -16,9 +16,7 @@ trigger:
       - develop
   paths:
     exclude:
-      - .azure-pipelines/*
       - .vscode/*
-      - tools/*
       - docs/*
       - README.md
 

--- a/.azure-pipelines/ci/pull-requests.yml
+++ b/.azure-pipelines/ci/pull-requests.yml
@@ -10,7 +10,6 @@ pr:
       - develop
   paths:
     exclude:
-      - .azure-pipelines/*
       - .vscode/*
       - docs/*
       - README.md

--- a/.azure-pipelines/manually/build-all.yml
+++ b/.azure-pipelines/manually/build-all.yml
@@ -17,8 +17,15 @@ stages:
     displayName: validate all and build all
     condition: ne(variables['ENV'], 'feat')
     jobs:
+      - job: node_deps
+        displayName: cache node dependencies
+        steps:
+          - template: ../templates/steps_install-node-modules.yml
+
       - job: lint_all
         displayName: nx lint all apps
+        dependsOn: node_deps
+        condition: succeeded()
         steps:
           - template: ../templates/steps_install-node-modules.yml
           - script: node ./tools/scripts/nx-run-all.js lint
@@ -26,6 +33,8 @@ stages:
 
       - job: test_all
         displayName: nx test all apps
+        dependsOn: node_deps
+        condition: succeeded()
         steps:
           - template: ../templates/steps_install-node-modules.yml
           - script: node ./tools/scripts/nx-run-all.js test

--- a/.azure-pipelines/manually/build-storybook.yml
+++ b/.azure-pipelines/manually/build-storybook.yml
@@ -17,8 +17,15 @@ stages:
     displayName: validate all and build storybook
     condition: eq(variables['ENV'], 'dev')
     jobs:
+      - job: node_deps
+        displayName: cache node dependencies
+        steps:
+          - template: ../templates/steps_install-node-modules.yml
+
       - job: lint_all
         displayName: nx lint all apps
+        dependsOn: node_deps
+        condition: succeeded()
         steps:
           - template: ../templates/steps_install-node-modules.yml
           - script: node ./tools/scripts/nx-run-all.js lint
@@ -26,6 +33,8 @@ stages:
 
       - job: test_all
         displayName: nx test all apps
+        dependsOn: node_deps
+        condition: succeeded()
         steps:
           - template: ../templates/steps_install-node-modules.yml
           - script: node ./tools/scripts/nx-run-all.js test

--- a/.azure-pipelines/manually/templates/build-one.yml
+++ b/.azure-pipelines/manually/templates/build-one.yml
@@ -11,8 +11,15 @@ stages:
     displayName: validate and build
     condition: ne('${{parameters.env}}', 'feat')
     jobs:
+      - job: node_deps
+        displayName: cache node dependencies
+        steps:
+          - template: ../../templates/steps_install-node-modules.yml
+
       - job: lint_one
         displayName: nx lint ${{parameters.appName}}
+        dependsOn: node_deps
+        condition: succeeded()
         steps:
           - template: ../../templates/steps_install-node-modules.yml
           - script: node ./tools/scripts/nx-run-one.js ${{parameters.appName}} lint
@@ -20,6 +27,8 @@ stages:
 
       - job: test_one
         displayName: nx test ${{parameters.appName}}
+        dependsOn: node_deps
+        condition: succeeded()
         steps:
           - template: ../../templates/steps_install-node-modules.yml
           - script: node ./tools/scripts/nx-run-one.js ${{parameters.appName}} test

--- a/.azure-pipelines/templates/steps_cache-npm.yml
+++ b/.azure-pipelines/templates/steps_cache-npm.yml
@@ -4,14 +4,34 @@
 # Cache task is missing (yaml pipeline)
 # https://developercommunity.visualstudio.com/content/problem/950320/cache-task-is-missing-yaml-pipeline.html?inRegister=true
 #
+parameters:
+  - name: npmConfigCache
+    type: string
+    default: '$(Pipeline.Workspace)/.npm'
+
 steps:
+  - script: |
+      echo $(Build.BuildNumber)
+      npm config get cache
+      npm config set cache ${{ parameters.npmConfigCache }} --global
+      npm config get cache
+    displayName: set npm cache directory
+
   # - task: Cache@2
   - task: CacheBeta@1
     inputs:
       key: 'npm | "$(Agent.OS)" | package-lock.json'
       restoreKeys: |
         npm | "$(Agent.OS)"
-        npm
+      path: ${{ parameters.npmConfigCache }}
+    displayName: Cache npm
+
+  # - task: Cache@2
+  - task: CacheBeta@1
+    inputs:
+      key: 'npm | "$(Agent.OS)" | "$(Build.BuildNumber)" | package-lock.json'
+      restoreKeys: |
+        npm | "$(Agent.OS)" | "$(Build.BuildNumber)"
       path: node_modules
       cacheHitVar: CACHE_RESTORED
     displayName: Cache node_modules


### PR DESCRIPTION
review the azure pipelines build flow and how it caches the `.npm/` and `node_modules/`

- the `.npm/` is a long term cache updated when a new change is made on the `package-lock.json`
- the `node_modules/` is cached only for the pipeline execution to reduce the pipeline execution time related to the `npm install` execution on each pipeline `job` or `stage` of the given pipeline